### PR TITLE
Change plugin directory and fix documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,14 @@ RUN go build -buildmode=plugin -o porton.so .
 # Gateway build
 FROM $IMAGE:$IMAGE_TAG
 
-# TODO: Run krakend as a non-root user
-
 # For more information see https://www.krakend.io/docs/enterprise/configuration/flexible-config/
 ENV FC_ENABLE=1
 
-RUN mkdir -p /usr/lib/krakend/plugins 
+# Ensure the plugins directory exists
+RUN mkdir -p /opt/krakend/plugins 
 
 # Copy plugins from the pluginbuilder
-COPY --from=pluginbuilder /go/src/porton/lib /usr/lib/krakend/plugins
+COPY --from=pluginbuilder /go/src/porton/lib /opt/krakend/plugins
+
+# Run as non-root user
+USER 1000

--- a/README.md
+++ b/README.md
@@ -12,18 +12,12 @@ before running this.
 Portón comes with Krakend's flexible configuration enabled by default
 [[1](https://www.krakend.io/docs/enterprise/configuration/flexible-config/)].
 
-The following directories are empty by default and should be populated
-by an orchestration engine if you want to take advantage of flexible configuration:
-
-* `/etc/krakend/settings`
-* `/etc/krakend/partials`
-* `/etc/krakend/templates`
-
-**NOTE**: These settings are **NOT** to be included into the container image,
-as they'll be dependent on the deployment and the services fronted by the gateway.
-
 Plugins are built and copied into the resulting container image. The directory
-containing the plugins is `/usr/lib/krakend/plugins`.
+containing the plugins is `/opt/krakend/plugins`.
+
+The base krakend configuration and directories for the flexible configuration are not included
+in the image. They are expected to be mounted into the container at runtime or
+built into an extended all-in-one image.
 
 # References
 


### PR DESCRIPTION
While using `/usr/lib` might have been better in terms of UNIX
philosophy. It's not ideal as the default directory for plugins really
is in `/opt`. Let's use that instead and stay within the current
patterns followed by krakend. Even if they're not UNIXy.

This also updates the docs to reflect both this change and previous ones
related to assumptions for the image in terms of krakend's flexible
configuration.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
